### PR TITLE
add some command linking and (bad) frecency links

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -76,3 +76,56 @@ export function generateDimension(argDimension, dimensionName) {
   return dimension
 }
 
+// This function is a little nuts, and probably not worth it. Use it as a 
+// tagged template literal (e.g. printIfExists`foo ${var} bar`) to print 
+// the string if `var` "exists" where "exists" is some pseudo definition 
+// that I made up. So yeah. There's that.
+export function printIfExists(strings, input, ...otherArgs) {
+  if (otherArgs.length > 0) {
+    throw new Error(`Unexpected usage! Use like ${printIfExists.name}\`before ${variable} after\`.`)
+  }
+
+  function wrap(str) {
+    return strings[0] + str + strings[1]
+  }
+
+  if (input !== undefined) {
+    if (input && Array.isArray(input) && input.length > 0) {
+      return wrap(input.join(', '))
+    }
+
+    else if (input && typeof input === 'object' && Object.keys(input).length > 0) {
+      try {
+        return wrap(JSON.stringify(input))
+      } catch (e) {
+        return wrap(input)
+      }
+    }
+
+    else if (
+      (typeof input === 'string' && input !== '') ||
+      (typeof input === 'number') ||
+      (typeof input === 'boolean')
+    ) {
+      return wrap(input)
+    }
+  }
+
+  // if we've fallen all the way through without returning, display nothing
+  return ''
+}
+
+export function handleValueAndTags(value, tags) {
+  // for a dumb edge-case where Number('') returns 0
+  let valueAsNumber = value === '' ? NaN : Number(value)
+  let valueIsNotNumber = Number.isNaN(valueAsNumber)
+  // prevents us from making an "undefined" tag when value is not provided
+  let valueIsTag = valueIsNotNumber && value !== undefined && value !== ''
+
+  let finalValue = valueIsNotNumber ? 1 : valueAsNumber
+  let finalTags = (valueIsTag ? [value, ...tags] : tags)
+    .map(tag => tag.trim()) // trim out spacing for the case where someone does `note <stream> '  tag'`
+    .filter(tag => tag !== '')
+
+  return { value: finalValue, tags: finalTags }
+}

--- a/nb.js
+++ b/nb.js
@@ -311,6 +311,7 @@ yargs(hideBin(process.argv))
           }
         })
         .demandCommand()
+        .strictCommands()
         .help()
     },
     handler: args => {
@@ -376,11 +377,13 @@ yargs(hideBin(process.argv))
           }
         })
         .demandCommand()
+        .strictCommands()
         .help()
     },
     handler: args => {
     }
   })
   .demandCommand()
+  .strictCommands()
   .help()
   .argv

--- a/server.js
+++ b/server.js
@@ -2,11 +2,15 @@ import { execSync } from 'child_process'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
+import flatfile from 'flat-file-db'  // docs: https://github.com/mafintosh/flat-file-db#api
+
 import server from 'server'
 const { get, post } = server.router
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 let nb = path.resolve(__dirname, 'nb.js')
+
+const db = flatfile.sync(path.join(__dirname, 'server-config.db'))
 
 // this function is only used by the web code
 // do not add any node-specific stuff in it
@@ -18,31 +22,91 @@ async function doCommand(event) {
   outputElement.innerHTML += text
 }
 
-function getCommandArgs(ctx, args = [], extra = '') {
-  return `${args.map(arg => ctx.params[arg]).join(' ')} ${extra}`.replace(/\s{2,}/g,' ').trim()
+function makeCommandsLinks(ctx, input) {
+  let isInCommandSection = false
+  let commandRegExp = /(nb\.js)\s+((?:(?!&|<|\[|  ).)+)\s/
+
+  let lines = input.split('\n')
+  .map(line => {
+
+    if (line.startsWith('nb.js')) {
+      let parsedLine = ''
+      line.split(' ').reduce((itemsSoFar, item) => {
+        let isAnArg = item.startsWith('&') || item.startsWith('[')
+        if (item !== 'nb.js' && !isAnArg) {
+          itemsSoFar.push(item)
+        }
+        if (!isAnArg) {
+          parsedLine += `<a href="/nb/${itemsSoFar.join(' ')}">${item}</a> `
+        } else {
+          parsedLine += `${item} `
+        }
+        return itemsSoFar
+      }, [])
+      return parsedLine
+    }
+
+    if (line.startsWith('Commands:')) {
+      isInCommandSection = true
+    } 
+    
+    else if (isInCommandSection && line.startsWith('  ')) {
+      return line.replace(commandRegExp, `$1 <a href="/nb/$2">$2</a> `)
+    } 
+    
+    else if (isInCommandSection && !line.startsWith('  ')) {
+      isInCommandSection = false
+    } 
+    
+    return line
+  })
+  return lines.join("\n")
 }
 
-function runAndRenderPage(ctx, args = [], extra = '') {
+function sanitizeHtml(input) {
+  return input.replace(/</g, '&#60;').replace(/>/g, '&#62;')
+}
+
+function runAndRenderPage(ctx, commandString) {
   return `<script>${doCommand.toString()}</script><pre>\n` +
-    runAndRender(ctx, args, `${extra} --help`) +
+    makeCommandsLinks(ctx, runAndRender(ctx, `${commandString} --help`)) +
     `\n\n` +
-    `<a href='#' onclick="doCommand(event)">run <b>nb.js ${getCommandArgs(ctx, args, extra)}</b></a>` +
+    `<a href='#' onclick="doCommand(event)">run <b>nb.js ${commandString}</b></a>` +
     `\n</pre>` +
     `<pre id="output"></pre>`
 }
 
-function runAndRender(ctx, args = [], extra = '') {
-  let command = `${nb} ${getCommandArgs(ctx, args, extra)}`
+function runAndRender(ctx, commandString) {
+  let command = `${nb} ${commandString}`
   let output
   try {
     output = execSync(command, { encoding: 'utf8' })
   } catch (e) {
     output = e.stdout + e.stderr
   }
+  
   console.log(`> ${command}`)
   console.log(output)
-  return `> nb.js ${getCommandArgs(ctx, args, extra)}\n\n`
-    + output.replace(/</g, '&#60;').replace(/>/g, '&#62;')
+
+  return `> nb.js ${sanitizeHtml(commandString)}\n\n`
+    + sanitizeHtml(output)
+}
+
+function getCommand(ctx) {
+  let commandString = decodeURIComponent(ctx.params.command).trim()
+  
+  let routes = db.get('recent') || {}
+  if (!routes[commandString]) routes[commandString] = 0
+  Object.keys(routes).forEach(key => {
+    if (key !== commandString) {
+      routes[key]--;
+      if (routes[key] < 0) delete routes[key]
+    }
+  })
+  routes[commandString] += 4;
+  db.put('recent', routes)
+
+  return commandString
 }
 
 const port = 8080
@@ -50,32 +114,28 @@ const port = 8080
 // because we're trying to be shape-agnostic, we don't care what the args are called so long as they exist
 // this functions makes handler routes for both the --help and the regular commands for a certain length
 
-// if we have 2 args, that means we need `/nb`, `/nb/arg1`, and `/nb/arg1/arg2`.
-// we need to create two methods like this for each of them:
-// get('/nb/:arg1/:arg2', ctx => runAndRenderPage(ctx, ["arg1", "arg2"]))
-// post('/nb/:arg1/:arg2', ctx => runAndRender(ctx, ["arg1", "arg2"]))
-
-function makeRoutes(root, totalNumberOfArgs = 0) {
-  // for each sub-length in the totalNumberOfArgs, make a new set of get/post
-  // (e.g. if totalNumberOfArgs === 2, we need to make routes with 0, 1, and 2 args)
-  return new Array(totalNumberOfArgs + 1).fill('arg').map((arg, index) => index)
-    .map(numberOfArgs => {
-      let args = new Array(numberOfArgs).fill('arg').map((arg, index) => arg + index)
-      let path = args.map(arg => `:${arg}`).join('/') || ''
-      return [
-        get(root + (path ? "/" : "") + path, async ctx => runAndRenderPage(ctx, args)),
-        post(root + (path ? "/" : "") + path, async ctx => runAndRender(ctx, args))
-      ]
-    })
-    .flat(2)
-}
-
 server({ port, security: { csrf: false }}, [
-  get('/', ctx => `<a href="nb">nb</a>`),
+  get('/', ctx => {
+
+    let recents = db.get('recent') 
+    let recentsText = ''
+    if (recents) {
+      recentsText = Object.entries(recents)
+        .sort((a, b) => b[1] - a[1]).map(([key]) => {
+          return `- <a href="nb/${key}">${key}</a>`
+        })
+        .join('<br />')
+    }
+    console.log()
+
+    return `<a href="nb">nb</a><br />${recentsText}`
+  }),
   
-  // handle a given number of args:
-  // this is total depth -- right now, this works
-  makeRoutes('/nb', 10)
+  get('/nb', ctx => runAndRenderPage(ctx, '')),
+  post('/nb', ctx => runAndRender(ctx, '')),
+
+  get('/nb/:command', ctx => runAndRenderPage(ctx, getCommand(ctx))),
+  post('/nb/:command', ctx => runAndRender(ctx, getCommand(ctx)))
 ]);
 
 console.log(`Listening on port ${port}...`)

--- a/server.js
+++ b/server.js
@@ -12,14 +12,8 @@ let nb = path.resolve(__dirname, 'nb.js')
 
 const db = flatfile.sync(path.join(__dirname, 'server-config.db'))
 
-// this function is only used by the web code
-// do not add any node-specific stuff in it
-// do not run it outside of the rendered output
-async function doCommand(event) {
-  event.preventDefault()
-  let text = await (await fetch(window.location.pathname, { method: 'POST' })).text()
-  let outputElement = document.querySelector('#output')
-  outputElement.innerHTML += text
+function changeCommand(event) {
+
 }
 
 function makeCommandsLinks(ctx, input) {
@@ -68,16 +62,52 @@ function sanitizeHtml(input) {
 }
 
 function runAndRenderPage(ctx, commandString) {
+  // this function is only used by the web code
+  // do not add any node-specific stuff in it
+  // do not run it outside of the rendered output
+  async function doCommand(event) {
+    event.preventDefault()
+    let text = await (await fetch(window.location.pathname, { method: 'POST' })).text()
+    let outputElement = document.querySelector('#output')
+    outputElement.innerHTML += text
+  }
+
   return `<script>${doCommand.toString()}</script><pre>\n` +
-    makeCommandsLinks(ctx, runAndRender(ctx, `${commandString} --help`)) +
+    makeCommandsLinks(ctx, runAndRender(ctx, commandString, '--help')) +
     `\n\n` +
     `<a href='#' onclick="doCommand(event)">run <b>nb.js ${commandString}</b></a>` +
     `\n</pre>` +
     `<pre id="output"></pre>`
 }
 
-function runAndRender(ctx, commandString) {
-  let command = `${nb} ${commandString}`
+function form(prefix, defaultValue, suffix) {
+  function onInput(event) {
+    document.querySelector('#spacer').innerHTML = ` ${event.target.value} `
+  }
+
+  function focusInput() {
+    document.querySelector('#command-input').focus()
+  }
+
+  function goToCommand(event) {
+    event.preventDefault()
+    window.location.pathname = `/nb/${encodeURIComponent(event.target[0].value)}`
+  }
+
+  let formStyle = `style="white-space: normal; display: inline-block;" `
+  let spanStyle = `style="white-space: pre;" `
+  let wrapperStyle = `style="position: relative; display: inline-block;" `
+  let inputStyle = `style="position: absolute; width: 100%; left: 0; border: 0; padding: 0; margin: 0; font-family: inherit; font-size: inherit; text-align: center;" `
+  return `<script>${onInput.toString()}; ${focusInput.toString()}; ${goToCommand.toString()};</script><form ${formStyle} onclick="focusInput()" onsubmit="goToCommand(event)">
+    <span ${spanStyle}>${prefix.trim()}</span><span ${wrapperStyle}>
+      <span id="spacer" ${spanStyle}> ${defaultValue} </span>
+      <input id="command-input" ${inputStyle} oninput="onInput(event)" value="${defaultValue.replace(/"/g,'\\"')}"></input>
+    </span><span ${spanStyle}>${suffix}</span>
+  </form>`
+}
+
+function runAndRender(ctx, commandString, nonEditableFlags) {
+  let command = `${nb} ${commandString} ${nonEditableFlags}`
   let output
   try {
     output = execSync(command, { encoding: 'utf8' })
@@ -88,7 +118,7 @@ function runAndRender(ctx, commandString) {
   console.log(`> ${command}`)
   console.log(output)
 
-  return `> nb.js ${sanitizeHtml(commandString)}\n\n`
+  return `> ${form(`nb.js `, sanitizeHtml(commandString), nonEditableFlags)}\n\n`
     + sanitizeHtml(output)
 }
 


### PR DESCRIPTION
This commit changes the way command urls are structured, make some of the commands in the help messages links, and adds a (bad) frecency list to the root page.

1. Command urls used to be formatted like this: `/nb/command/arg1/arg2/arg3`. This worked fine, but isn't easily extensible and seemed strange. I mostly did it to not have to deal with `%20`s from spaces. I've gotten over that, and command urls are now structured like this: `/nb/command arg1 arg2 arg3` (or `/nb/command%20arg1%20arg2%20arg3`). This means that they're still always linkable, but are a lot more flexible.
2. Help messages that display subcommands (e.g. a `Commands:` section) now link to them. In addition, every command has links back to the parent command.
3. I wanted a frecency list so that I can easily do things I've done before/recently. That has been added. It's bad, but it exists. It'll get better.
